### PR TITLE
Relicense to MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright 2014 Red Hat, Inc. and/or its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         "Programming Language :: Python",
         "Development Status :: 4 - Beta",
         "Operating System :: POSIX :: Linux",
-        "License :: OSI Approved :: Python Software Foundation License"],
+        "License :: OSI Approved :: MIT License"],
     packages=['merkyl'],
     entry_points={'console_scripts':
                   ['merkyl = merkyl:main']},

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     description="Log file tailer with bottle",
     author="Pete Savage",
     keywords=["tail", "linux", "bottle"],
-    license="PSF",
+    license="MIT",
     classifiers=[
         "Programming Language :: Python",
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
The PSF license is widely used in the Python world but it's really not appropriate if you're not the PSF and since the issue came up I thought I'd suggest changing to the (policywise similar) MIT license.