### PR TITLE
Make merkyl compatible with python 2.7

### DIFF
--- a/merkyl/__init__.py
+++ b/merkyl/__init__.py
@@ -10,7 +10,7 @@ try:
     with open(sys.argv[2], "r") as f:
         allowed_files = f.readlines()
 except IOError:
-    print "allowed.files not found, exiting"
+    print("allowed.files not found, exiting")
     sys.exit(127)
 allowed_files = [path.strip("\n") for path in allowed_files]
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ setup(
         "Programming Language :: Python",
         "Development Status :: 4 - Beta",
         "Operating System :: POSIX :: Linux",
-        "License :: OSI Approved :: MIT License"],
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2.7",],
     packages=['merkyl'],
     entry_points={'console_scripts':
                   ['merkyl = merkyl:main']},


### PR DESCRIPTION
When I try to use merkyl the following error occur:
```shell
$ merkyl 8192 allowed.files
Traceback (most recent call last):
  File "/home/hbd/.local/bin/merkyl", line 7, in <module>
    from merkyl import main
  File "/home/hbd/.local/lib/python3.5/site-packages/merkyl/__init__.py", line 13
    print "allowed.files not found, exiting"
                                           ^
SyntaxError: Missing parentheses in call to 'print'
```

So this merge request simply add parentheses to the `print` statement and display python versions who are compatible with merkyl by using [pypi classifiers](https://pypi.org/classifiers/)